### PR TITLE
fix(rtprelay): correct RTPEngine ng protocol parameters for WebRTC bridging

### DIFF
--- a/mods/rtprelay/src/utils.ts
+++ b/mods/rtprelay/src/utils.ts
@@ -65,22 +65,20 @@ export function getRTPEParamsByDirection(dir: Direction) {
     case Direction.WEB_TO_PHONE:
       return {
         "transport-protocol": "RTP/AVP",
-        "rtcp-mux": "demux",
+        DTLS: "off",
         ICE: "remove",
-        flags: ["trust-address", "replace-origin", "replace-session-connection"]
+        "rtcp-mux": ["demux"],
+        replace: ["origin", "session-connection"],
+        flags: ["trust-address", "SDES-no"]
       }
     case Direction.PHONE_TO_WEB:
       return {
         "transport-protocol": "UDP/TLS/RTP/SAVPF",
-        "rtcp-mux": "require",
         ICE: "force",
-        SDES: ["off"],
-        flags: [
-          "trust-address",
-          "replace-origin",
-          "replace-session-connection",
-          "generate-mid"
-        ]
+        DTLS: "passive",
+        "rtcp-mux": ["require"],
+        replace: ["origin", "session-connection"],
+        flags: ["SDES-no", "generate mid", "strip-extmap"]
       }
     case Direction.PHONE_TO_PHONE:
       return {


### PR DESCRIPTION
## Summary

WebRTC clients (SIP.js) calling PSTN via RTPEngine receive an SDP answer missing the DTLS fingerprint, causing Chrome to reject with: "Failed to set remote answer sdp: Called with SDP without DTLS fingerprint."

The root cause is that the RTPEngine ng protocol parameters for `WEB_TO_PHONE` and `PHONE_TO_WEB` directions were incorrectly formatted, causing RTPEngine to silently ignore critical directives:

- **`rtcp-mux`** was sent as a string (`"demux"`) instead of the required array (`["demux"]`), causing RTPEngine to ignore it entirely
- **`DTLS`** was never explicitly set — the phone leg needs `"off"` and the WebRTC leg needs `"passive"` for RTPEngine to properly generate the DTLS fingerprint and set the correct handshake role
- **`SDES`** and **`replace`** were using non-standard formats that differ from the ng protocol spec

These changes align with the [drachtio/rtpengine-client](https://github.com/drachtio/drachtio-rtpengine-webrtcproxy) reference implementation used in production WebRTC-to-SIP bridging.

## Test plan

- [ ] Verify WebRTC (SIP.js) to internal SIP endpoint call connects with two-way audio
- [ ] Verify WebRTC to PSTN via Twilio trunk — SDP answer contains `a=fingerprint:` and `a=setup:passive`
- [ ] Verify SIP-to-SIP (PHONE_TO_PHONE) calls are unaffected
- [ ] Verify WEB_TO_WEB calls are unaffected


Made with [Cursor](https://cursor.com)