### PR TITLE
docs: polish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,121 +9,57 @@
 <a href="https://gitpod.io/#https://github.com/fonoster/routr"> <img src="https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod" alt="Contribute with Gitpod" />
 </a> [![Sponsor this](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&link=https://github.com/sponsors/fonoster)](https://github.com/sponsors/fonoster) [![Discord](https://img.shields.io/discord/1016419835455996076?color=5865F2&label=Discord&logo=discord&logoColor=white)](https://discord.com/invite/4QWgSz4hTC) ![GitHub](https://img.shields.io/github/license/fonoster/routr?color=%2347b96d) ![Twitter Follow](https://img.shields.io/twitter/follow/fonoster?style=social)
 
-Routr is a lightweight sip proxy, location server, and registrar that provides a reliable and scalable SIP infrastructure for telephony carriers, communication service providers, and integrators.
+Routr is a lightweight SIP proxy, location server, and registrar that provides a reliable and scalable SIP infrastructure for telephony carriers, communication service providers, and integrators.
 
-## Content
+## Table of Contents
 
-* [Community](#community)
-* [Should you try Routr?](#should-you-try-routr)
-* [Contact us](#contact-us)
-* [Features](#features)
-* [The official handbook](#the-official-handbook)
-* [Deployment](#deployment)
-    * [Docker](#instant-server-deployment-with-docker-and-compose)
-    * [Kubernetes](#kubernetes)  
-    * [Gitpod](#development-mode-with-gitpod)
-* [Getting started with the CTL](#getting-started-with-the-ctl)
-* [First steps with the NodeSDK](#first-steps-with-the-nodesdk)
-* [Custom Processors and Middleware](#building-custom-processors-and-middleware)
-* [Documentation](https://routr.io/docs)
-* [Bugs and feedback](#bugs-and-feedback)
-* [Sponsors](#sponsors)
-* [Contributing](#contributing)
-* [License](#license)
-
-## Community
-
-We are building Routr in the open. The best to communicate with us is via [GitHub Discussions.](https://github.com/fonoster/routr/discussions)
-
----
-
-<p align="center">
-  <sup>Special Announcement:</sup>
-  <br>
-  <a href="https://discord.gg/mpWSRUhG7e">
-    <img width="70px" src="https://assets-global.website-files.com/6257adef93867e50d84d30e2/625e5fcef7ab80b8c1fe559e_Discord-Logo-Color.png">
-  </a>
-  <br>
-  <sub><b>We now have a Discord Channel</b></sub>
-  <br>
-  <sub>There we plan to discuss roadmaps, feature requests, and more<br><a href="https://discord.com/invite/4QWgSz4hTC">Join us today</a></sub>
-</p>
-
----
-
-## Should you try Routr?
-
-> Routr's architecture and design is fantastic. A breath of fresh air. Being Docker and Kubernetes ready is a huge win over a more traditional SIP server setup.
->
-> [Phil Jones](https://www.linkedin.com/in/phil-jones-4346884a/), VP of Web Architecture at VQ Communications
-
-> I came across Routr, which seems to be the one and only cloud-first Kubernetes-ready SIP server on the planet!
-> 
-> [Jessie Wadman](https://www.jessiewadman.se/), Cloud Architect @ Camanio AB
-
-> Awesome and one of the best open-source software in 2023.
-> 
-> [no-championship-s368](https://www.reddit.com/r/linux/comments/11xdvo5/routr_v2_the_future_of_programmable_sip_servers/), Check conversation @ Reddit
-
-> I think this project has a great promise to become a transformative technology.
-> 
-> [jbwill36](https://github.com/orgs/fonoster/discussions/209), Check conversation @ GitHub
-
-## Contact us
-
-Meet our sales team for any commercial inquiries.
-
-<a href="https://cal.com/psanders"><img src="https://cal.com/book-with-cal-dark.svg" alt="Book us with Cal.com"></a>
+- [Features](#features)
+- [Deployment](#deployment)
+  - [Docker](#docker)
+  - [Kubernetes](#kubernetes)
+  - [Gitpod (Development)](#gitpod-development)
+- [Getting Started with the CTL](#getting-started-with-the-ctl)
+- [Getting Started with the Node SDK](#getting-started-with-the-node-sdk)
+- [Building Custom Processors and Middleware](#building-custom-processors-and-middleware)
+- [The Official Handbook](#the-official-handbook)
+- [Testimonials](#testimonials)
+- [Community](#community)
+- [Bugs and Feedback](#bugs-and-feedback)
+- [Contributing](#contributing)
+- [Sponsors](#sponsors)
+- [Authors](#authors)
+- [License](#license)
 
 ## Features
 
-Routr's main features are:
-
-- [x] Common SIP Server functions; Proxy, Registrar, Location Service
+- [x] Common SIP Server functions: Proxy, Registrar, Location Service
 - [x] Programmable routing
 - [x] Load balancing strategies against Media Servers like Asterisk and FreeSWITCH
-- [x] Session Affinity 
-- [x] Multi-Tenant/Multi-Domain with Domain level Access Control List
-- [ ] Region-based routing
-- [x] Configurable routing strategies; Intra-Domain, Domain Ingress, Domain Egress, and Peer Egress
+- [x] Session Affinity
+- [x] Multi-Tenant/Multi-Domain with domain-level Access Control Lists
+- [x] Configurable routing strategies: Intra-Domain, Domain Ingress, Domain Egress, and Peer Egress
 - [x] No single point of failure
 - [x] Transport: TCP, UDP, TLS, WS, WSS
-- [x] In-memory and Redis Location Service 
+- [x] In-memory and Redis Location Service
 - [x] JSON and YAML files as a data source
 - [x] Postgres as a data source
 - [x] Server management with the gRPC API
-- [x] NodeSDK
-- [x] Command-Line Tool
+- [x] Node SDK
+- [x] Command-Line Tool (CTL)
 - [x] RTPEngine Middleware
-- [x] Helm Chart for  Kubernetes Deployments
-- [x] Endpoint Authentication with JWT (For web phones)
+- [x] Helm Chart for Kubernetes deployments
+- [x] Endpoint authentication with JWT (for web phones)
+- [ ] Region-based routing
 - [ ] Support for STIR/SHAKEN
 - [ ] Web Application
 
-To learn more, read the [documentation](https://routr.io/docs) :books:
-
-## The official handbook
-
-<a href="https://fonoster.gumroad.com/l/the-future-of-programmable-sip-servers">
-<img src="https://raw.githubusercontent.com/psanders/psanders/master/book.png" width="300px"></a>
-
-This handbook offers a detailed information about of the innovative features, challenges, and opportunities associated with using Routr.
-
-Get the eBook.
-
-* [Programmable, cloud-ready, open source](https://fonoster.gumroad.com/l/the-future-of-programmable-sip-servers)
-
-## Give a star! ⭐
-
-If you want to support this project, please give it a star. Thanks 🙏
+To learn more, read the [documentation](https://routr.io/docs).
 
 ## Deployment
 
-### Instant server deployment with Docker and Compose
+### Docker
 
-First, create a directory named "routr". Navigate into the new folder, and then copy the content below:
-
-Filename: _compose.yaml_
+Create a `compose.yaml` file with the following content:
 
 ```yaml
 version: "3"
@@ -143,17 +79,17 @@ volumes:
   shared:
 ```
 
-Then, start the server with:
+Start the server with Docker Compose:
 
 ```bash
-# Be sure to replace with your IP address
+# Replace with your host's IP address
 DOCKER_HOST_ADDRESS=192.168.1.3 docker-compose up
 ```
 
-Alternatively, you can use the following command:
+Or run directly with Docker:
 
 ```bash
-# Be sure to replace with your IP address
+# Replace with your host's IP address
 docker run \
   -p 51908:51908 \
   -p 5060:5060/udp \
@@ -161,109 +97,95 @@ docker run \
   fonoster/routr-one:latest
 ```
 
-Wait a few seconds for the containers to initialize. Afterward, you can verify the status of the containers using:
+Wait a few seconds for the container to initialize, then verify it is running:
 
 ```bash
 docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}'
 ```
 
-You should see a container with the status "Up." It should look like the one below:
+You should see output like this:
 
-```bash
-CONTAINER ID  IMAGE                                     STATUS
-6c63fd573768  fonoster/routr-one:latest                 Up About a minute
+```
+CONTAINER ID  IMAGE                         STATUS
+6c63fd573768  fonoster/routr-one:latest      Up About a minute
 ```
 
-If the status of your services is "Up," you are ready to go.
+If the status shows "Up," you are ready to go.
 
 ### Kubernetes
 
-Routr can be installed in Kubernetes using Helm. The following instructions assume that you have a Kubernetes cluster up and running. 
+Routr can be installed in Kubernetes using Helm. These instructions assume you have a running Kubernetes cluster (you can use [Minikube](https://minikube.sigs.k8s.io/) or Docker Desktop for local development).
 
-> You can use Minikube or Docker Desktop to create a local Kubernetes cluster.
-
-First, add the Helm repository:
+Add the Helm repository:
 
 ```bash
 helm repo add routr https://routr.io/charts
 helm repo update
 ```
 
-Then, create a namespace for Routr:
+Create a namespace and install Routr:
 
 ```bash
 kubectl create namespace routr
-```
-
-Next, install Routr with the following command:
-
-```bash
 helm install my-release routr/routr-connect --namespace routr
 ```
 
-Finally, wait a few minutes for the pods to start. You can check the status of the pods with the following command:
+Wait a few minutes for the pods to start, then check their status:
 
 ```bash
 kubectl get pods -n routr
 ```
 
-You should see a list of pods and their status. If the status is Running, then you are ready to go.
+All pods should show a status of `Running`. For more details, see the chart's [README](https://github.com/fonoster/routr/blob/main/ops/charts/connect/README.md).
 
-For more details, please refer to the chart's [README](https://github.com/fonoster/routr/blob/main/ops/charts/connect/README.md).
+### Gitpod (Development)
 
-### Development mode with Gitpod
-
-Routr's one-click interactive deployment will familiarize you with the server in development mode.
+For a one-click development environment, open the project in Gitpod:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/fonoster/routr)
 
-To connect to your instance, follow these steps:
+To connect to your Gitpod instance via SSH:
 
-First, add your public SSH keys to your Gitpod account by going to [Gitpod account keys](https://gitpod.io/user/keys) and adding your public key.
-
-Next, find your [Gitpod workspace](https://gitpod.io/workspaces) and click on the "More" button. Then, select "Connect via SSH."
-
-Finally, copy the SSH Command and run it in your terminal by pasting it and pressing Enter. The command should look like this:
+1. Add your public SSH key at [Gitpod account keys](https://gitpod.io/user/keys).
+2. Open your [Gitpod workspaces](https://gitpod.io/workspaces), click "More" on your workspace, and select "Connect via SSH."
+3. Copy the SSH command and run it in your terminal with port forwarding:
 
 ```bash
+# Replace <workspace-ssh-connection> with your actual connection string
 ssh -L 5060:localhost:5060 <workspace-ssh-connection>
 ```
 
-Replace <workspace-ssh-connection> with your own workspace SSH connection.
-
-For example, your command might look like this:
+For example:
 
 ```bash
 ssh -L 5060:localhost:5060 fonoster-routr-mn8nsx0d9px@fonoster-routr-mn8nsx0d9px.ssh.ws-us90.gitpod.io
 ```
 
-This command forwards traffic from your local port 5060 to your Gitpod workspace's port 5060, allowing you to access your instance.
+This forwards traffic from your local port 5060 to the Gitpod workspace, allowing you to reach the SIP server.
 
-## Getting started with the CTL
+## Getting Started with the CTL
 
-Regadles of the deployment method, you can use the command-line tool to manage your server.
+Regardless of the deployment method, you can manage your Routr server using the command-line tool.
 
-To install the command-line tool, run the following command:
+Install it globally via npm:
 
 ```bash
 npm install --location=global @routr/ctl
 ```
 
-We are using the flag `--location=global` to tell npm to install the command-line tool globally. If you don't have npm installed, you can follow the instructions here: https://nodejs.org/en/download/.
+> If you don't have npm installed, follow the instructions at [nodejs.org](https://nodejs.org/en/download/).
 
-Here is an example of how to create a domain:
+Here is an example of creating a domain:
 
 ```bash
 rctl domains create --insecure
 ```
 
-The `--insecure` flag, in the last example, is required because no certificate was provided to secure the API. 
+> The `--insecure` flag is required when no TLS certificate has been configured for the API.
 
-Follow the prompts to create the domain.
+Follow the interactive prompts. The output will look like this:
 
-The output should look like this:
-
-```bash
+```
 This utility will help you create a new Domain.
 Press ^C at any time to quit.
 ? Friendly Name Local Domain
@@ -273,25 +195,20 @@ Press ^C at any time to quit.
 Creating Domain Local Domain... a27e9fb2-a71a-4cf3-9b1d-dccf373f9777
 ```
 
-For additional examples, refer to the command line [documentation.](https://www.npmjs.com/package/@routr/ctl)
+For more examples, see the [CTL documentation](https://www.npmjs.com/package/@routr/ctl).
 
-## First steps with the NodeSDK
+## Getting Started with the Node SDK
 
-To begin using the Node.js SDK, first make sure you have Node and NPM installed. Then, start by creating a new project and installing the Routr Connect SDK.
+Make sure you have Node.js and npm installed, then create a new project:
 
 ```bash
 mkdir my-project
 cd my-project
 npm init -y
-```
-
-Next, install the SDK:
-
-```bash
 npm install --save @routr/sdk
 ```
 
-Now, create a new file called `index.js` and add the following code:
+Create a file called `index.js`:
 
 ```javascript
 const SDK = require("@routr/sdk");
@@ -301,40 +218,39 @@ const domains = new SDK.Domains();
 const request = {
   name: "Local domain",
   domainUri: "sip.local",
-  accessControlListRef: "4671371b-ff5d-48b1-aabe-d3c5ca5317a3", 
+  accessControlListRef: "4671371b-ff5d-48b1-aabe-d3c5ca5317a3",
   egressPolicies: [{
     rule: ".*",
     numberRef: "4671371b-ff5d-48b1-aabe-d3c5ca5317a3"
   }],
   extended: {
     "key": "value"
-  } 
+  }
 };
 
-domains.createDomain(request) 
+domains.createDomain(request)
   .then(console.log)
-  .catch(console.error); // an error occurred
+  .catch(console.error);
 ```
 
-> In the example above, we assume that the ACL and Number already exist.
+> The example above assumes that the ACL and Number already exist.
 
-Now, go ahead and run the code:
+Run it:
 
 ```bash
 node index.js
 ```
 
-For complete documentation, please visit the npm page for `@routr/sdk` at https://www.npmjs.com/package/@routr/sdk
+For complete documentation, visit the [@routr/sdk](https://www.npmjs.com/package/@routr/sdk) npm page.
 
-## Building custom Processors and Middleware
+## Building Custom Processors and Middleware
 
-One of Routr's most significant advantages is that it is highly extensible. It enables you to create new Processors and Middleware to extend the functionality of your server.
+Routr is highly extensible. You can create custom Processors and Middleware to modify SIP messages as they pass through the server.
 
-Processors and Middleware services are responsible for modifying the SIP messages as they pass through the server. However, while both share the same interface, they serve different purposes.
+- **Processors** hold feature logic.
+- **Middleware** addresses cross-cutting concerns like authentication, authorization, and rate limiting.
 
-Processors hold feature logic; Middlewares addresses cross-cutting concerns like authentication, authorization, rate limiting, etc.
-
-The simplest possible Processor looks like this:
+Both share the same interface. Here is a minimal Processor that responds with `200 OK` to every request:
 
 ```javascript
 const Processor = require("@routr/processor").default
@@ -349,27 +265,60 @@ new Processor({ bindAddr: "0.0.0.0:51904", name: "echo" }).listen(
 )
 ```
 
-The previous example is for a Processor that waits for a SIP message and then sends a 200 OK response. You can find the complete code [here](https://github.com/fonoster/routr/tree/main/mods/echo).
+You can find the complete code in the [echo module](https://github.com/fonoster/routr/tree/main/mods/echo).
 
-In addition to the previous example, you can check the following modules:
+For more examples, see:
 
+- [Connect Processor](https://github.com/fonoster/routr/tree/main/mods/connect)
 - [RTPRelay Middleware](https://github.com/fonoster/routr/tree/main/mods/rtprelay)
 - [Simple Auth Middleware](https://github.com/fonoster/routr/tree/main/mods/simpleauth)
 - [Processor Template](https://github.com/fonoster/nodejs-processor/tree/main)
-- [Connect Processor](https://github.com/fonoster/routr/tree/main/mods/connect)
 
-For more information about building Processors and Middleware, please refer to the [documentation.](https://routr.io/docs)
+For full details on building Processors and Middleware, see the [documentation](https://routr.io/docs).
 
-## Bugs and feedback
+## The Official Handbook
 
-For bugs, questions, and discussions, please use the [Github Issues](https://github.com/fonoster/routr/issues)
+<a href="https://fonoster.gumroad.com/l/the-future-of-programmable-sip-servers">
+<img src="https://raw.githubusercontent.com/psanders/psanders/master/book.png" width="300px"></a>
+
+This handbook covers the architecture, features, and deployment of Routr in depth.
+
+[Get the eBook &rarr;](https://fonoster.gumroad.com/l/the-future-of-programmable-sip-servers)
+
+## Testimonials
+
+> Routr's architecture and design is fantastic. A breath of fresh air. Being Docker and Kubernetes ready is a huge win over a more traditional SIP server setup.
+>
+> &mdash; [Phil Jones](https://www.linkedin.com/in/phil-jones-4346884a/), VP of Web Architecture at VQ Communications
+
+> I came across Routr, which seems to be the one and only cloud-first Kubernetes-ready SIP server on the planet!
+>
+> &mdash; [Jessie Wadman](https://www.jessiewadman.se/), Cloud Architect at Camanio AB
+
+> Awesome and one of the best open-source software in 2023.
+>
+> &mdash; [no-championship-s368](https://www.reddit.com/r/linux/comments/11xdvo5/routr_v2_the_future_of_programmable_sip_servers/), Reddit
+
+> I think this project has a great promise to become a transformative technology.
+>
+> &mdash; [jbwill36](https://github.com/orgs/fonoster/discussions/209), GitHub
+
+## Community
+
+We are building Routr in the open. The best way to communicate with us is via [GitHub Discussions](https://github.com/fonoster/routr/discussions) or our [Discord server](https://discord.com/invite/4QWgSz4hTC).
+
+<a href="https://cal.com/psanders"><img src="https://cal.com/book-with-cal-dark.svg" alt="Book us with Cal.com"></a>
+
+## Bugs and Feedback
+
+For bugs, questions, and discussions, please use [GitHub Issues](https://github.com/fonoster/routr/issues).
 
 ## Contributing
 
 For contributing, please see the following links:
 
- - [Contribution Documents](https://github.com/fonoster/routr/blob/master/CONTRIBUTING.md)
- - [Contributors](https://github.com/fonoster/routr/contributors)
+- [Contribution Guidelines](https://github.com/fonoster/routr/blob/master/CONTRIBUTING.md)
+- [Contributors](https://github.com/fonoster/routr/contributors)
 
 <!--contributors:start-->
 
@@ -447,14 +396,16 @@ For contributing, please see the following links:
 
 We're glad to be supported by respected companies and individuals from several industries.
 
-Find all our supporters [here](https://github.com/sponsors/fonoster)
-
-> [Become a Github Sponsor](https://github.com/sponsors/fonoster)
+[Find all our supporters here](https://github.com/sponsors/fonoster) &middot; [Become a GitHub Sponsor](https://github.com/sponsors/fonoster)
 
 ## Authors
 
- - [Pedro Sanders](https://github.com/psanders)
+- [Pedro Sanders](https://github.com/psanders)
 
 ## License
 
-Copyright (C) 2024 by [Fonoster Inc](https://fonoster.com). MIT License (see [LICENSE](https://github.com/fonoster/fonoster/blob/master/LICENSE) for details).
+Copyright (C) 2026 by [Fonoster Inc](https://fonoster.com). MIT License (see [LICENSE](https://github.com/fonoster/routr/blob/main/LICENSE) for details).
+
+---
+
+If you find Routr useful, please consider giving it a star on GitHub. It helps others discover the project.


### PR DESCRIPTION
## Summary
- Reorganizes the README for clearer onboarding and navigation
- Tightens deployment, CTL, SDK, and middleware sections
- Fixes grammar, wording, and stale links while preserving existing project details

## Verification
- Checked README internal anchors with a Python script
- Ran `npx --yes prettier@2.6.2 --check README.md`