### PR TITLE
fix(connect): return 400/404 instead of 500 for peer-to-pstn routing

### DIFF
--- a/mods/common/src/response.ts
+++ b/mods/common/src/response.ts
@@ -76,3 +76,29 @@ export const createForbiddenResponse = (metadata?: Record<string, string>) => {
     }
   }
 }
+
+export const createBadRequestResponse = (
+  reasonPhrase = "Bad Request",
+  metadata?: Record<string, string>
+) => {
+  return {
+    metadata,
+    message: {
+      responseType: ResponseType.BAD_REQUEST,
+      reasonPhrase
+    }
+  }
+}
+
+export const createNotFoundResponse = (
+  reasonPhrase = "Not Found",
+  metadata?: Record<string, string>
+) => {
+  return {
+    metadata,
+    message: {
+      responseType: ResponseType.NOT_FOUND,
+      reasonPhrase
+    }
+  }
+}

--- a/mods/connect/src/router.ts
+++ b/mods/connect/src/router.ts
@@ -201,12 +201,13 @@ export function router(location: ILocationService, apiClient: CC.APIClient) {
         )
         return result(routingDirection, route, callee.extended)
       }
-      case RoutingDirection.PEER_TO_PSTN:
-        return result(
-          routingDirection,
-          await peerToPSTN(apiClient, request),
-          callee?.extended
-        )
+      case RoutingDirection.PEER_TO_PSTN: {
+        const routeOrResponse = await peerToPSTN(apiClient, request)
+        // An error response (e.g. Bad Request, Not Found) is returned as-is
+        return "message" in routeOrResponse
+          ? routeOrResponse
+          : result(routingDirection, routeOrResponse as Route, callee?.extended)
+      }
       default:
         throw new UnsupportedRoutingError(routingDirection)
     }
@@ -377,13 +378,20 @@ async function agentToPeer(
 async function peerToPSTN(
   apiClient: CC.APIClient,
   req: MessageRequest
-): Promise<Route> {
+): Promise<Route | Record<string, unknown>> {
   const numberTel = E.getHeaderValue(req, CT.ExtraHeader.DOD_NUMBER)
   const privacy = E.getHeaderValue(req, CT.ExtraHeader.DOD_PRIVACY)
+
+  if (!numberTel) {
+    return CR.createBadRequestResponse(
+      `Missing or empty '${CT.ExtraHeader.DOD_NUMBER}' header required for peer-to-pstn routing`
+    )
+  }
+
   const number = await findNumberByTelUrl(apiClient, `tel:${numberTel}`)
 
   if (!number) {
-    throw new Error(`no Number found for tel: ${numberTel}`)
+    return CR.createNotFoundResponse(`No Number found for tel:${numberTel}`)
   }
 
   if (!number.trunk) {

--- a/mods/connect/test/connect.unit.test.ts
+++ b/mods/connect/test/connect.unit.test.ts
@@ -185,6 +185,49 @@ describe("@routr/connect", () => {
       .lengthOf(5)
   })
 
+  it("returns Bad Request when X-Dod-Number is missing for peer to pstn", async () => {
+    const req = createRequest({
+      fromUser: "asterisk",
+      fromDomain: "unknown.com",
+      toUser: "+17853178070",
+      toDomain: "unknown.com"
+      // dodNumber intentionally omitted
+    })
+    const reqWithUpdatedAuth = Helper.deepCopy(req)
+    reqWithUpdatedAuth.message.authorization.response =
+      "09f30fe20face5e168ca7dafcbf154c0"
+
+    const result = await router(locationAPI, apiClient)(reqWithUpdatedAuth)
+
+    expect(result).to.not.have.property("direction")
+    expect(result)
+      .to.have.property("message")
+      .to.have.property(
+        "responseType",
+        CommonTypes.ResponseType.BAD_REQUEST
+      )
+  })
+
+  it("returns Not Found when the X-Dod-Number resource does not exist", async () => {
+    const req = createRequest({
+      fromUser: "asterisk",
+      fromDomain: "unknown.com",
+      toUser: "+17853178070",
+      toDomain: "unknown.com",
+      dodNumber: "+10000000000"
+    })
+    const reqWithUpdatedAuth = Helper.deepCopy(req)
+    reqWithUpdatedAuth.message.authorization.response =
+      "09f30fe20face5e168ca7dafcbf154c0"
+
+    const result = await router(locationAPI, apiClient)(reqWithUpdatedAuth)
+
+    expect(result).to.not.have.property("direction")
+    expect(result)
+      .to.have.property("message")
+      .to.have.property("responseType", CommonTypes.ResponseType.NOT_FOUND)
+  })
+
   it("gets resource by domainUri and userpart", async () => {
     const r1 = await findResource(apiClient, "sip.local", "1001")
     // Domain with xxx reference does not exist

--- a/mods/connect/test/connect.unit.test.ts
+++ b/mods/connect/test/connect.unit.test.ts
@@ -202,10 +202,7 @@ describe("@routr/connect", () => {
     expect(result).to.not.have.property("direction")
     expect(result)
       .to.have.property("message")
-      .to.have.property(
-        "responseType",
-        CommonTypes.ResponseType.BAD_REQUEST
-      )
+      .to.have.property("responseType", CommonTypes.ResponseType.BAD_REQUEST)
   })
 
   it("returns Not Found when the X-Dod-Number resource does not exist", async () => {


### PR DESCRIPTION
## Summary

Fixes #276. When routing `peer-to-pstn`, `peerToPSTN()` threw a generic `Error` if the `X-DOD-Number` header was missing or the referenced Number didn't exist. That bubbled up to the request handler's catch block and was returned to the caller as a **500 Internal Server Error**.

This change returns proper SIP error responses instead:

- **400 Bad Request** when `X-DOD-Number` is missing or empty
- **404 Not Found** when no Number matches the `tel:` URL

Each response carries a descriptive reason phrase that is propagated all the way to the SIP status line (connect → processor `send()` → EdgePort `setReasonPhrase()`), so the caller sees, e.g.:

- `SIP/2.0 400 Missing or empty 'X-DOD-Number' header required for peer-to-pstn routing`
- `SIP/2.0 404 No Number found for tel:+10000000000`

## Changes

- `mods/common/src/response.ts` — add `createBadRequestResponse` (400) and `createNotFoundResponse` (404) helpers, mirroring the existing `createForbiddenResponse` pattern.
- `mods/connect/src/router.ts` — `peerToPSTN` returns these responses instead of throwing; the `PEER_TO_PSTN` case forwards error responses as-is.
- `mods/connect/test/connect.unit.test.ts` — add unit tests for both the missing-header and number-not-found cases.

## Testing

- `npm test` — all unit tests pass, including the two new cases.
- Type-check and lint clean.