### PR TITLE
feat(edgeport): add STRIP_SESSION_PROGRESS_SDP env flag to strip SDP from 183

### DIFF
--- a/mods/edgeport/src/main/java/io/routr/GRPCSipListener.java
+++ b/mods/edgeport/src/main/java/io/routr/GRPCSipListener.java
@@ -60,6 +60,7 @@ public class GRPCSipListener implements SipListener {
   private final TransactionManager transactionManager;
   private final EventProcessor eventProcessor;
   private final AuthenticationHandler authenticationHandler;
+  private final boolean stripSessionProgressSdp;
 
   public GRPCSipListener(final SipProvider sipProvider, final Map<String, Object> config,
       final List<String> externalAddrs, final List<String> localnets)
@@ -75,6 +76,8 @@ public class GRPCSipListener implements SipListener {
     String processorAddrEnv = System.getenv("PROCESSOR_ADDR");
     String ignoreLoopbackEnv = System.getenv("IGNORE_LOOPBACK_FROM_LOCALNETS");
     String hostnameEnv = System.getenv("HOSTNAME");
+    String stripSessionProgressSdpEnv = System.getenv("STRIP_SESSION_PROGRESS_SDP");
+    this.stripSessionProgressSdp = Boolean.parseBoolean(stripSessionProgressSdpEnv);
 
     if (processorAddrEnv != null) {
       addr = processorAddrEnv;
@@ -274,6 +277,12 @@ public class GRPCSipListener implements SipListener {
 
       if (ResponseHelper.isStackJob(res)) {
         return;
+      }
+
+      if (stripSessionProgressSdp
+          && ResponseHelper.hasCodes(res, Response.SESSION_PROGRESS)) {
+        res.removeContent();
+        res.removeHeader(ContentTypeHeader.NAME);
       }
 
       var isTransactional = ResponseHelper.isTransactional(event, res);

--- a/mods/edgeport/src/test/java/io/routr/utils/ResponseHelperTest.java
+++ b/mods/edgeport/src/test/java/io/routr/utils/ResponseHelperTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 by Fonoster Inc (https://fonoster.com)
+ * http://github.com/fonoster/routr
+ *
+ * This file is part of Routr.
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.routr.utils;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sip.message.MessageFactory;
+import javax.sip.message.Response;
+import javax.sip.SipFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResponseHelperTest {
+
+  @Test
+  public void hasCodesIdentifies183SessionProgress() throws Exception {
+    MessageFactory messageFactory = SipFactory.getInstance().createMessageFactory();
+    Response sessionProgress = messageFactory.createResponse(
+        "SIP/2.0 183 Session Progress\r\n\r\n");
+    Response ok = messageFactory.createResponse(
+        "SIP/2.0 200 OK\r\n\r\n");
+
+    assertTrue(ResponseHelper.hasCodes(sessionProgress, Response.SESSION_PROGRESS));
+    assertFalse(ResponseHelper.hasCodes(ok, Response.SESSION_PROGRESS));
+  }
+}

--- a/mods/requester/src/test/java/io/routr/requester/SIPProviderBuilderTests.java
+++ b/mods/requester/src/test/java/io/routr/requester/SIPProviderBuilderTests.java
@@ -19,15 +19,27 @@
 package io.routr.requester;
 
 import org.junit.jupiter.api.Test;
+
 import javax.sip.*;
+import java.io.IOException;
+import java.net.ServerSocket;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SIPProviderBuilderTests {
 
+  private static int findFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+
   @Test
-  public void testCreateSipProvider() throws PeerUnavailableException, TransportNotSupportedException, InvalidArgumentException,
-  ObjectInUseException, TransportAlreadySupportedException {
-    SipProvider provider = SIPProviderBuilder.createSipProvider(null, "localhost:5060");
+  public void testCreateSipProvider() throws Exception {
+    // Use a dynamically chosen free port so the test does not fail with BindException when 5060 is in use.
+    // JAIN SIP does not accept port 0.
+    int port = findFreePort();
+    SipProvider provider = SIPProviderBuilder.createSipProvider(null, "localhost:" + port);
     assertNotNull(provider);
     assertEquals(2, provider.getListeningPoints().length);
     assertEquals("tcp", provider.getListeningPoint("tcp").getTransport().toLowerCase());


### PR DESCRIPTION
## What

Adds a `STRIP_SESSION_PROGRESS_SDP` environment flag in the EdgePort. When enabled, the EdgePort strips the SDP body from `183 Session Progress` responses.

## Why

Some upstreams send early-media SDP in 183 that causes interop problems; this flag lets operators suppress it without code changes.

## Notes

- Rebased onto current `main`; the original branch also carried a `chore(release): publish v2.14.0` bump created by the release bot, which was intentionally dropped here so the release pipeline can handle versioning normally.
- Changes are scoped to `GRPCSipListener.java` plus tests (`ResponseHelperTest.java`, `SIPProviderBuilderTests.java`).