### PR TITLE
chore: reconcile base version to 2.14.0 so next release is 2.15.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["mods/*"],
-  "version": "2.13.23",
+  "version": "2.14.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/mods/common/package.json
+++ b/mods/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/common",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Common package",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",

--- a/mods/connect/package.json
+++ b/mods/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/connect",
-  "version": "2.13.22",
+  "version": "2.14.0",
   "description": "Default processor",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -28,9 +28,9 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/location": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/location": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {

--- a/mods/ctl/package.json
+++ b/mods/ctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/ctl",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Routr Command-Line Tool",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "bin": {
@@ -25,8 +25,8 @@
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.1.12",
     "@oclif/plugin-warn-if-update-available": "^2.0.19",
-    "@routr/common": "^2.13.20",
-    "@routr/sdk": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/sdk": "^2.14.0",
     "figlet": "^1.9.4",
     "fuzzy-search": "^3.2.1",
     "inquirer": "^8.2.7",

--- a/mods/dispatcher/package.json
+++ b/mods/dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/dispatcher",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Receives SIP messages and forwards them to the corresponding Message Processor",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -35,8 +35,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "ajv": "^6.12.6",
     "fp-ts": "^2.11.8"
   },

--- a/mods/echo/package.json
+++ b/mods/echo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/echo",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Dummy implementation of a Processor service",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -28,8 +28,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20"
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0"
   },
   "files": [
     "dist"

--- a/mods/edgeport/package.json
+++ b/mods/edgeport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/edgeport",
-  "version": "2.13.23",
+  "version": "2.14.0",
   "description": "SIP endpoint at the edge of the network",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -29,7 +29,7 @@
     "url": "https://github.com/fonoster/routr/issues"
   },
   "dependencies": {
-    "@routr/common": "^2.13.20",
+    "@routr/common": "^2.14.0",
     "ajv": "^6.12.6",
     "fp-ts": "^2.11.8",
     "js-yaml": "^4.1.1",

--- a/mods/location/package.json
+++ b/mods/location/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/location",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Creates and maintains a list of routes to all registered endpoints",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -35,8 +35,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "ajv": "^6.12.6",
     "fp-ts": "^2.11.8",
     "redis": "^4.0.4"

--- a/mods/one/package.json
+++ b/mods/one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/one",
-  "version": "2.13.22",
+  "version": "2.14.0",
   "description": "Bundle server with everything needed to run Routr Connect",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "@fonoster/logger": "0.6.0",
-    "@routr/common": "^2.13.20",
-    "@routr/connect": "^2.13.22",
-    "@routr/dispatcher": "^2.13.20",
-    "@routr/location": "^2.13.20",
-    "@routr/pgdata": "^2.13.22",
-    "@routr/rtprelay": "^2.13.20"
+    "@routr/common": "^2.14.0",
+    "@routr/connect": "^2.14.0",
+    "@routr/dispatcher": "^2.14.0",
+    "@routr/location": "^2.14.0",
+    "@routr/pgdata": "^2.14.0",
+    "@routr/rtprelay": "^2.14.0"
   },
   "files": [
     "dist"

--- a/mods/pgdata/package.json
+++ b/mods/pgdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/pgdata",
-  "version": "2.13.22",
+  "version": "2.14.0",
   "description": "Postgres API Server for Routr Connect",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -33,8 +33,8 @@
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
     "@prisma/client": "^6.19.1",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "google-protobuf": "^3.21.4",
     "grpc-health-check": "^2.1.0",
     "pb-util": "^1.0.3",

--- a/mods/processor/package.json
+++ b/mods/processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/processor",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Processor server and API",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -23,7 +23,7 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
+    "@routr/common": "^2.14.0",
     "fp-ts": "^2.11.8",
     "phone": "^3.1.68"
   },

--- a/mods/registry/package.json
+++ b/mods/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/registry",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Sends trunks registrations and maintains their bindings",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -35,8 +35,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "ajv": "^6.12.6",
     "express": "^4.22.1",
     "fp-ts": "^2.11.8",

--- a/mods/requester/package.json
+++ b/mods/requester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/requester",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "SIP requests as an API",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",

--- a/mods/rtprelay/package.json
+++ b/mods/rtprelay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/rtprelay",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Media Relay for Routr using RTPengine",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -29,8 +29,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "rtpengine-client": "^0.4.11"
   },
   "files": [

--- a/mods/sdk/package.json
+++ b/mods/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/sdk",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "The Routr SDK for Node.js",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -27,7 +27,7 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
+    "@routr/common": "^2.14.0",
     "google-protobuf": "^3.21.4",
     "pb-util": "^1.0.3"
   },

--- a/mods/simpleauth/package.json
+++ b/mods/simpleauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/simpleauth",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "This middleware delegates authentication to an external service",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -29,8 +29,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "google-protobuf": "^3.21.4"
   },
   "files": [

--- a/mods/simpledata/package.json
+++ b/mods/simpledata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routr/simpledata",
-  "version": "2.13.20",
+  "version": "2.14.0",
   "description": "Files-based API Server for Routr Connect",
   "author": "Pedro Sanders <psanders@fonoster.com>",
   "homepage": "https://github.com/fonoster/routr#readme",
@@ -30,8 +30,8 @@
     "@opentelemetry/sdk-trace-base": "^1.0.4",
     "@opentelemetry/sdk-trace-node": "^1.0.4",
     "@opentelemetry/semantic-conventions": "^1.0.4",
-    "@routr/common": "^2.13.20",
-    "@routr/processor": "^2.13.20",
+    "@routr/common": "^2.14.0",
+    "@routr/processor": "^2.14.0",
     "google-protobuf": "^3.21.4",
     "jsonpath": "^1.1.1",
     "pb-util": "^1.0.3"


### PR DESCRIPTION
## Why

`@routr/*@2.14.0` was published to npm from a side branch (`feat/strip-session-progress-sdp`) but never reflected on `main`. That version number is now permanently burned on npm.

The release workflow computes the next version as `lerna.json` base + bump keyword. With main at `2.13.23` and a `feat` commit present, it would compute **minor → 2.14.0**, which collides with the burned npm version and fails at publish.

## What

Aligns `main`'s base version (lerna.json + all `mods/*` package.json + internal `@routr/*` dependency ranges) to **2.14.0**. After this merges, the release workflow's minor bump lands on **2.15.0**, cleanly skipping the burned 2.14.x line.

No code changes — versions only. The subsequent release will contain the wss-recursion fix, rtprelay WebRTC params, peer-to-pstn error codes, and the STRIP_SESSION_PROGRESS_SDP feature.