### PR TITLE
ci: fix heplify download URL (404) for routr-one and edgeport images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --update cmake curl g++ git make nodejs npm openjdk17-jdk
   && cd node_modules/@routr/pgdata/ && npx prisma@6.12.0 generate \
   && cd /work && curl -sf https://gobinaries.com/tj/node-prune | sh && node-prune 
 
-ADD https://github.com/sipcapture/heplify/releases/download/v1.67.0/heplify /work/heplify
+ADD https://github.com/sipcapture/heplify/releases/download/v1.67.1/heplify /work/heplify
 RUN chmod +x heplify
 
 ##  

--- a/mods/edgeport/Dockerfile
+++ b/mods/edgeport/Dockerfile
@@ -43,7 +43,7 @@ COPY .scripts/convert-to-p12.sh .
 COPY .scripts/generate-certs.sh .
 
 RUN apk add --no-cache curl libcap openssl sed sngrep tini \
-  && curl -L -o heplify https://github.com/sipcapture/heplify/releases/download/v1.65.10/heplify \
+  && curl -fL -o heplify https://github.com/sipcapture/heplify/releases/download/v1.67.1/heplify \
   && chmod +x heplify \
   && chmod +x edgeport.sh convert-to-p12.sh generate-certs.sh \
   && mkdir -p ${PATH_TO_CERTS} ${PATH_TO_LOGS} \


### PR DESCRIPTION
## Problem

The v2.15.0 release run failed publishing the **Routr One** Docker image:

```
ADD https://github.com/sipcapture/heplify/releases/download/v1.67.0/heplify
ERROR: failed to build: ... invalid response status 404
```

`sipcapture/heplify` **v1.67.0** (root `Dockerfile`) and **v1.65.10** (`mods/edgeport/Dockerfile`) were removed upstream and now 404. The EdgePort image only "built" because it used `curl -L` (no `-f`), silently saving the 404 page as the `heplify` binary — so that image currently ships a broken binary.

## Fix

- Pin both Dockerfiles to **v1.67.1** (verified the `heplify` asset returns HTTP 200).
- Verified the only flag we use — `-hs` (set via `HEPLIFY_OPTIONS`, e.g. `-hs homerserver:9060`) — is unchanged in v1.67.1 (`flag.StringVar(&config.Cfg.HepServer, "hs", ...)`).
- Switch EdgePort to `curl -fL` so a future missing asset fails the build loudly.

No application code changes; classified as `ci:` so it does not trigger a version bump.