### PR TITLE
fix(charts): correct registry edgeport address and repoint bitnami images

### DIFF
--- a/ops/charts/connect/Chart.yaml
+++ b/ops/charts/connect/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: routr-connect
 description: Routr Connect Helm Chart
 type: application
-version: 0.4.3
-appVersion: 2.13.6
+version: 0.5.0
+appVersion: 2.15.0
 dependencies:
   - name: postgresql
     version: 16.2.2

--- a/ops/charts/connect/templates/edgeport/service.yaml
+++ b/ops/charts/connect/templates/edgeport/service.yaml
@@ -1,0 +1,55 @@
+# Internal service for the EdgePort (in-cluster traffic only).
+#
+# Unlike the per-protocol LoadBalancer services (service-udp.yaml / service-tcp.yaml)
+# which exist to satisfy cloud load-balancers that cannot mix UDP and TCP on a single
+# external service, this is a headless ClusterIP service used for in-cluster traffic
+# only -- e.g. the Registry sending outbound REGISTERs through the EdgePort. ClusterIP
+# services are not subject to that load-balancer limitation, so this exposes every
+# enabled transport behind a single, transport-agnostic address regardless of how the
+# external services are split. It also backs the EdgePort StatefulSet as its governing
+# service.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-routr-edgeport
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include ".helm.labels" . | nindent 4 }}
+    service: edgeport
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  {{- if .Values.edgeport.transport.udp.enabled }}
+    - name: sipudp
+      protocol: UDP
+      port: {{ .Values.edgeport.transport.udp.port | default 5060 }}
+      targetPort: {{ .Values.edgeport.transport.udp.port | default 5060 }}
+  {{- end }}
+  {{- if .Values.edgeport.transport.tcp.enabled }}
+    - name: siptcp
+      protocol: TCP
+      port: {{ .Values.edgeport.transport.tcp.port | default 5060 }}
+      targetPort: {{ .Values.edgeport.transport.tcp.port | default 5060 }}
+  {{- end }}
+  {{- if .Values.edgeport.transport.tls.enabled }}
+    - name: siptls
+      protocol: TCP
+      port: {{ .Values.edgeport.transport.tls.port | default 5061 }}
+      targetPort: {{ .Values.edgeport.transport.tls.port | default 5061 }}
+  {{- end }}
+  {{- if .Values.edgeport.transport.ws.enabled }}
+    - name: sipws
+      protocol: TCP
+      port: {{ .Values.edgeport.transport.ws.port | default 5062 }}
+      targetPort: {{ .Values.edgeport.transport.ws.port | default 5062 }}
+  {{- end }}
+  {{- if .Values.edgeport.transport.wss.enabled }}
+    - name: sipwss
+      protocol: TCP
+      port: {{ .Values.edgeport.transport.wss.port | default 5063 }}
+      targetPort: {{ .Values.edgeport.transport.wss.port | default 5063 }}
+  {{- end }}
+  selector:
+    {{- include ".helm.selectorLabels" . | nindent 4 }}
+    service: edgeport

--- a/ops/charts/connect/templates/edgeport/statefulset.yaml
+++ b/ops/charts/connect/templates/edgeport/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include ".helm.selectorLabels" . | nindent 6 }}
       service: edgeport
-  serviceName: edgeport
+  serviceName: {{ .Release.Name }}-routr-edgeport
   minReadySeconds: {{ .Values.edgeport.minReadySeconds }}
   template:
     metadata:

--- a/ops/charts/connect/templates/registry/configmaps.yaml
+++ b/ops/charts/connect/templates/registry/configmaps.yaml
@@ -31,4 +31,8 @@ data:
       {{- end }}
       {{- end }}
       edgePorts:
+        # Internal headless EdgePort service (see edgeport/service.yaml). The transport
+        # used for outbound REGISTERs is trunk-driven, so this single address must be
+        # transport-agnostic; the port is hardcoded to the standard SIP port (5060),
+        # which both UDP and TCP listen on by default.
         - address: {{ .Release.Name }}-routr-edgeport.{{ .Release.Namespace }}:5060

--- a/ops/charts/connect/values.yaml
+++ b/ops/charts/connect/values.yaml
@@ -554,10 +554,13 @@ rtprelay:
     # Target memory utilization percentage
     targetMemoryUtilizationPercentage: 70
 
-# Postgresql Service defaults 
+# Postgresql Service defaults
 postgresql:
   # Whether to enable PostgreSQL
   enabled: true
+  image:
+    # Bitnami sunset docker.io/bitnami; legacy tags live under bitnamilegacy (see #317)
+    repository: bitnamilegacy/postgresql
   auth:
     # Initial username for the database
     username: routr
@@ -569,5 +572,8 @@ redis:
   # Whether to enable Redis
   enabled: true
   architecture: standalone
+  image:
+    # Bitnami sunset docker.io/bitnami; legacy tags live under bitnamilegacy (see #317)
+    repository: bitnamilegacy/redis
   auth:
     enabled: false


### PR DESCRIPTION
## Summary

Two related Helm chart breakages that prevent `routr-connect` from installing/running cleanly. **Do not merge yet — pending a live cluster test.**

### #312 — registry points at a non-existent EdgePort service
Commit `9679d04` split the single `*-routr-edgeport` service into `*-routr-edgeport-udp` / `*-routr-edgeport-tcp` to satisfy cloud load-balancers that cannot mix UDP and TCP on one `LoadBalancer` service (#223). But the registry configmap **and** the EdgePort StatefulSet's `serviceName` still referenced the old combined name, leaving both unresolvable.

Key point: that split is only needed for **external ingress**. The registry → EdgePort hop is **internal**, and ClusterIP services have no UDP/TCP-mixing limitation. So instead of coupling internal addressing to the external LB layout, this adds a dedicated **headless ClusterIP service** (`templates/edgeport/service.yaml`) that exposes every enabled transport behind one transport-agnostic address. Both the registry and the StatefulSet `serviceName` now target it. The external per-protocol `LoadBalancer` services are unchanged, so DigitalOcean compatibility is preserved.

The transport of each REGISTER is trunk-driven (`mods/registry/src/utils.ts:104` → `request.ts:52` → `RequestSender.java:75`), so a single transport-agnostic internal address is exactly what's needed; the port is the standard SIP port (5060).

### #317 — Bitnami images no longer resolve
Bitnami sunset `docker.io/bitnami`; the postgres/redis tags pinned by the vendored subcharts now only exist under `bitnamilegacy`, so `helm install` pulls non-existent images. Repoint the subchart image repositories to `bitnamilegacy`.

> ⚠️ `bitnamilegacy` is a **workaround** (frozen namespace). Durable migration tracked in #347.

## Verification (`helm template`)

| Case | Result |
|---|---|
| New internal service (default) | `test-routr-edgeport` headless ClusterIP, `sipudp` 5060 ✅ |
| New internal service (udp+tcp) | both `sipudp` **and** `siptcp` on 5060 on one service ✅ |
| Registry address | `test-routr-edgeport.default:5060` → matches the new service ✅ |
| StatefulSet `serviceName` | `test-routr-edgeport` (was dangling `edgeport`) ✅ |
| External LB services | `test-routr-edgeport-udp` / `-tcp` unchanged ✅ |
| #317 images | `docker.io/bitnamilegacy/{postgresql,redis}` ✅ |
| `helm lint` | passes ✅ |

Still TODO before merge: live install on a cluster to confirm the registry/requester reaches the EdgePort through the new headless service.

Closes #312
Closes #317