### PR TITLE
ci: collapse Docker Hub publish jobs into a single matrix job

### DIFF
--- a/.claude/kaizen/log.md
+++ b/.claude/kaizen/log.md
@@ -1,0 +1,10 @@
+# Kaizen ledger
+
+One repo, one improvement, every day. 改善.
+
+This log is the memory of the `kaizen` skill. Each run reads it to avoid repeating
+picks and to rotate across lenses. Newest entries first.
+
+| Date | Lens | Improvement | Status | Branch / note |
+| :--- | :--- | :--- | :--- | :--- |
+| 2026-07-06 | ci | Collapse 13 near-identical Docker Hub publish jobs in `docker-hub-release.yaml` into one matrix job | done | kaizen/2026-07-06-matrix-docker-hub-publish |

--- a/.github/workflows/docker-hub-release.yaml
+++ b/.github/workflows/docker-hub-release.yaml
@@ -39,81 +39,58 @@ jobs:
     outputs:
       version: ${{ steps.release.outputs.VERSION }}
 
-  publish_one_to_docker_hub:
-    name: Publish Routr One to Docker Hub
+  publish_to_docker_hub:
+    name: Publish ${{ matrix.image }} to Docker Hub
 
     runs-on: ubuntu-latest
 
     needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the Routr One image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-one
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
 
-  publish_edgeport_to_docker_hub:
-    name: Publish EdgePort to Docker Hub
+    strategy:
+      matrix:
+        include:
+          - image: routr-one
+            context: .
+            dockerfile: Dockerfile
+          - image: routr-edgeport
+            context: .
+            dockerfile: mods/edgeport/Dockerfile
+          - image: routr-dispatcher
+            context: mods/dispatcher
+            dockerfile: mods/dispatcher/Dockerfile
+          - image: routr-location
+            context: mods/location
+            dockerfile: mods/location/Dockerfile
+          - image: routr-connect
+            context: mods/connect
+            dockerfile: mods/connect/Dockerfile
+          - image: routr-simpledata
+            context: mods/simpledata
+            dockerfile: mods/simpledata/Dockerfile
+          - image: routr-simpleauth
+            context: mods/simpleauth
+            dockerfile: mods/simpleauth/Dockerfile
+          - image: routr-requester
+            context: .
+            dockerfile: mods/requester/Dockerfile
+          - image: routr-registry
+            context: mods/registry
+            dockerfile: mods/registry/Dockerfile
+          - image: routr-pgdata
+            context: .
+            dockerfile: mods/pgdata/Dockerfile
+            buildoptions: "--target runner"
+          - image: routr-pgdata-migrations
+            context: .
+            dockerfile: mods/pgdata/Dockerfile
+            buildoptions: "--target migrations"
+          - image: routr-echo
+            context: mods/echo
+            dockerfile: mods/echo/Dockerfile
+          - image: routr-rtprelay
+            context: mods/rtprelay
+            dockerfile: mods/rtprelay/Dockerfile
 
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the Edgeport image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-edgeport
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          context: .
-          dockerfile: mods/edgeport/Dockerfile
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_dispatcher_to_docker_hub:
-    name: Publish Dispatcher to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-dispatcher
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/dispatcher
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_location_to_docker_hub:
-    name: Publish Location to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
     steps:
       - name: Download build
         uses: actions/download-artifact@v4
@@ -124,221 +101,11 @@ jobs:
       - name: Publish the image
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:
-          name: fonoster/routr-location
+          name: fonoster/${{ matrix.image }}
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/location
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_connect_to_docker_hub:
-    name: Publish Connect to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-connect
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/connect
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_simpledata_to_docker_hub:
-    name: Publish SimpleData to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-simpledata
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/simpledata
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_simpleauth_to_docker_hub:
-    name: Publish SimpleAuth to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-simpleauth
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/simpleauth
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_requester_to_docker_hub:
-    name: Publish Requester to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-requester
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: .
-          dockerfile: mods/requester/Dockerfile
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_registry_to_docker_hub:
-    name: Publish Registry to Docker Hub
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-registry
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/registry
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_pgdata_to_docker_hub:
-    name: Publish the PGData image
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-pgdata
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          context: .
-          dockerfile: mods/pgdata/Dockerfile
-          buildoptions: "--target runner"
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_pgdata_migrations_to_docker_hub:
-    name: Publish the Postgres DB Migrations image
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-pgdata-migrations
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          context: .
-          dockerfile: mods/pgdata/Dockerfile
-          buildoptions: "--target migrations"
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_echo_to_docker_hub:
-    name: Publish the Echo image
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-echo
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/echo
-          tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
-          platforms: linux/amd64,linux/arm64
-
-  publish_rtprelay_to_docker_hub:
-    name: Publish the RTPrelay image
-
-    runs-on: ubuntu-latest
-
-    needs: [download_artifacts]
-    steps:
-      - name: Download build
-        uses: actions/download-artifact@v4
-        with:
-          name: routr-build
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Publish the image
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: fonoster/routr-rtprelay
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          workdir: mods/rtprelay
+          context: ${{ matrix.context }}
+          dockerfile: ${{ matrix.dockerfile }}
+          buildoptions: ${{ matrix.buildoptions }}
           tags: "latest,${{ needs.download_artifacts.outputs.VERSION }}"
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary
- `docker-hub-release.yaml` had 13 near-identical `publish_*_to_docker_hub` jobs (283 lines), differing only in image name, build context, and dockerfile path
- Collapsed them into a single matrix job (`publish_to_docker_hub`) driven by a 13-entry matrix; adding a new image is now a one-line matrix entry instead of a copy-pasted job

Behavior is preserved exactly: I traced the `elgohr/Publish-Docker-Github-Action` entrypoint script to confirm `workdir: mods/X` (cd, then build with default context) is functionally identical to `context: mods/X`, so every job's image name, build context, Dockerfile, and `buildoptions` (for the two pgdata variants) match the original 1:1.

## Test plan
- [x] Parsed the new workflow YAML and diffed the matrix `include` list against the 13 original jobs' `name`/`workdir`/`context`/`dockerfile`/`buildoptions` values — all 13 match
- [x] Confirmed no other workflow or branch-protection rule references the old job IDs (`gh api repos/fonoster/routr/branches/main/protection`)
- [ ] Watch the first real `workflow_dispatch` / release run to confirm all 13 images still publish with the same tags